### PR TITLE
kwnlp: Make inclusion of Wikidata item statements optional

### DIFF
--- a/kwnlp_preprocessor/__init__.py
+++ b/kwnlp_preprocessor/__init__.py
@@ -1,2 +1,2 @@
 # Copyright 2021-present Kensho Technologies, LLC.
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/kwnlp_preprocessor/argconfig.py
+++ b/kwnlp_preprocessor/argconfig.py
@@ -5,7 +5,6 @@ import multiprocessing
 import sys
 from typing import Dict, List
 
-
 DEFAULT_KWNLP_DATA_PATH: str = ""
 DEFAULT_KWNLP_WIKI_MIRROR_URL: str = "https://dumps.wikimedia.org"
 DEFAULT_KWNLP_WIKI: str = "enwiki"
@@ -75,6 +74,14 @@ ap_loglevel.add_argument(
     type=int,
 )
 
+ap_include_item_statements = argparse.ArgumentParser(add_help=False)
+ap_include_item_statements.add_argument(
+    "--include_item_statements",
+    default=False,
+    help="whether to produce the wikidata item statements output",
+    type=bool,
+)
+
 
 ARGS: Dict[str, argparse.ArgumentParser] = {
     "wp_yyyymmdd": ap_wp_yyyymmdd,
@@ -86,6 +93,7 @@ ARGS: Dict[str, argparse.ArgumentParser] = {
     "max_entities": ap_max_entities,
     "workers": ap_workers,
     "loglevel": ap_loglevel,
+    "include_item_statements": ap_include_item_statements,
 }
 
 

--- a/kwnlp_preprocessor/run_all_tasks.py
+++ b/kwnlp_preprocessor/run_all_tasks.py
@@ -2,26 +2,27 @@
 import logging
 from typing import List
 
-from kwnlp_preprocessor import argconfig
-from kwnlp_preprocessor import task_00_download_raw_dumps
-from kwnlp_preprocessor import task_03p1_create_kwnlp_pagecounts
-from kwnlp_preprocessor import task_03p2_convert_sql_to_csv
-from kwnlp_preprocessor import task_06p1_create_kwnlp_page_props
-from kwnlp_preprocessor import task_06p2_create_kwnlp_redirect_it2
-from kwnlp_preprocessor import task_09p1_create_kwnlp_ultimate_redirect
-from kwnlp_preprocessor import task_12p1_create_kwnlp_title_mapper
-from kwnlp_preprocessor import task_15p1_split_and_compress_wikidata
-from kwnlp_preprocessor import task_18p1_filter_wikidata_dump
-from kwnlp_preprocessor import task_21p1_gather_wikidata_chunks
-from kwnlp_preprocessor import task_24p1_create_kwnlp_article_pre
-from kwnlp_preprocessor import task_27p1_parse_wikitext
-from kwnlp_preprocessor import task_30p1_post_process_link_chunks
-from kwnlp_preprocessor import task_33p1_collect_post_processed_link_data
-from kwnlp_preprocessor import task_36p1_collect_template_data
-from kwnlp_preprocessor import task_36p2_collect_length_data
-from kwnlp_preprocessor import task_39p1_create_kwnlp_article
-from kwnlp_preprocessor import task_42p1_collect_section_names
-
+from kwnlp_preprocessor import (
+    argconfig,
+    task_00_download_raw_dumps,
+    task_03p1_create_kwnlp_pagecounts,
+    task_03p2_convert_sql_to_csv,
+    task_06p1_create_kwnlp_page_props,
+    task_06p2_create_kwnlp_redirect_it2,
+    task_09p1_create_kwnlp_ultimate_redirect,
+    task_12p1_create_kwnlp_title_mapper,
+    task_15p1_split_and_compress_wikidata,
+    task_18p1_filter_wikidata_dump,
+    task_21p1_gather_wikidata_chunks,
+    task_24p1_create_kwnlp_article_pre,
+    task_27p1_parse_wikitext,
+    task_30p1_post_process_link_chunks,
+    task_33p1_collect_post_processed_link_data,
+    task_36p1_collect_template_data,
+    task_36p2_collect_length_data,
+    task_39p1_create_kwnlp_article,
+    task_42p1_collect_section_names,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,7 @@ def main(
     jobs_to_download: List[str] = argconfig.DEFAULT_KWNLP_DOWNLOAD_JOBS.split(","),
     max_entities: int = argconfig.DEFAULT_KWNLP_MAX_ENTITIES,
     workers: int = argconfig.DEFAULT_KWNLP_WORKERS,
+    include_item_statements: bool = False,
 ) -> None:
 
     task_00_download_raw_dumps.main(
@@ -60,6 +62,7 @@ def main(
         wiki=wiki,
         workers=workers,
         max_entities=max_entities,
+        include_item_statements=include_item_statements,
     )
     task_21p1_gather_wikidata_chunks.main(wd_yyyymmdd, data_path=data_path)
     task_24p1_create_kwnlp_article_pre.main(

--- a/kwnlp_preprocessor/task_03p1_create_kwnlp_pagecounts.py
+++ b/kwnlp_preprocessor/task_03p1_create_kwnlp_pagecounts.py
@@ -13,8 +13,8 @@ import logging
 import os
 import time
 import typing
-from kwnlp_preprocessor import argconfig
 
+from kwnlp_preprocessor import argconfig
 
 logger = logging.getLogger(__name__)
 

--- a/kwnlp_preprocessor/task_03p2_convert_sql_to_csv.py
+++ b/kwnlp_preprocessor/task_03p2_convert_sql_to_csv.py
@@ -2,9 +2,10 @@
 """Convert raw SQL dumps into CSVs."""
 import logging
 import os
-from kwnlp_sql_parser.wp_sql_dump import WikipediaSqlDump
-from kwnlp_preprocessor import argconfig
 
+from kwnlp_sql_parser.wp_sql_dump import WikipediaSqlDump
+
+from kwnlp_preprocessor import argconfig
 
 logger = logging.getLogger(__name__)
 ARTICLE_NAMESPACE = ("0",)

--- a/kwnlp_preprocessor/task_06p1_create_kwnlp_page_props.py
+++ b/kwnlp_preprocessor/task_06p1_create_kwnlp_page_props.py
@@ -2,9 +2,10 @@
 """Update page_props format."""
 import logging
 import os
-import pandas as pd
-from kwnlp_preprocessor import argconfig
 
+import pandas as pd
+
+from kwnlp_preprocessor import argconfig
 
 logger = logging.getLogger(__name__)
 

--- a/kwnlp_preprocessor/task_06p2_create_kwnlp_redirect_it2.py
+++ b/kwnlp_preprocessor/task_06p2_create_kwnlp_redirect_it2.py
@@ -2,9 +2,10 @@
 """Add source page titles and target page ids to redirect CSV."""
 import logging
 import os
-import pandas as pd
-from kwnlp_preprocessor import argconfig
 
+import pandas as pd
+
+from kwnlp_preprocessor import argconfig
 
 logger = logging.getLogger(__name__)
 

--- a/kwnlp_preprocessor/task_09p1_create_kwnlp_ultimate_redirect.py
+++ b/kwnlp_preprocessor/task_09p1_create_kwnlp_ultimate_redirect.py
@@ -11,9 +11,10 @@ In the process we remove cycles (self redirects, circular pairs, ...)
 """
 import logging
 import os
-import pandas as pd
-from kwnlp_preprocessor import argconfig
 
+import pandas as pd
+
+from kwnlp_preprocessor import argconfig
 
 logger = logging.getLogger(__name__)
 

--- a/kwnlp_preprocessor/task_12p1_create_kwnlp_title_mapper.py
+++ b/kwnlp_preprocessor/task_12p1_create_kwnlp_title_mapper.py
@@ -8,9 +8,10 @@ For redirect titles it will map to the ultimate redirect article page id.
 """
 import logging
 import os
-import pandas as pd
-from kwnlp_preprocessor import argconfig
 
+import pandas as pd
+
+from kwnlp_preprocessor import argconfig
 
 logger = logging.getLogger(__name__)
 

--- a/kwnlp_preprocessor/task_15p1_split_and_compress_wikidata.py
+++ b/kwnlp_preprocessor/task_15p1_split_and_compress_wikidata.py
@@ -13,8 +13,8 @@ from typing import Iterable
 
 import funcy
 from qwikidata.json_dump import WikidataJsonDump
-from kwnlp_preprocessor import argconfig
 
+from kwnlp_preprocessor import argconfig
 
 logger = logging.getLogger(__name__)
 

--- a/kwnlp_preprocessor/task_18p1_filter_wikidata_dump.py
+++ b/kwnlp_preprocessor/task_18p1_filter_wikidata_dump.py
@@ -18,9 +18,9 @@ logger = logging.getLogger(__name__)
 
 SKIP_INSTANCES_OF_NQID = frozenset(
     [
-        13442814,  # scholarly article
+        13442814,
     ]
-)
+)  # scholarly article
 
 RANK_TO_INT = {"deprecated": 2, "normal": 1, "preferred": 0}
 
@@ -103,24 +103,25 @@ def parse_file(args: Dict) -> None:
         item_alias_writer = csv.DictWriter(item_alias_fp, fieldnames=fieldnames)
         item_alias_writer.writeheader()
 
-        item_statements_file_path = os.path.join(
-            args["data_path"],
-            "wikidata-derived-{}".format(args["wd_yyyymmdd"]),
-            "item-statements-chunks",
-            "kwnlp-{}-item-statements.csv".format(args["out_file_base"]),
-        )
-        os.makedirs(os.path.dirname(item_statements_file_path), exist_ok=True)
-        item_statements_fp = exit_stack.enter_context(open(item_statements_file_path, "w"))
-        fieldnames = [
-            "statement_id",
-            "mainsnak_datatype",
-            "datavalue_datatype",
-            "source_item_id",
-            "edge_property_id",
-            "target_datavalue",
-        ]
-        item_statements_writer = csv.DictWriter(item_statements_fp, fieldnames=fieldnames)
-        item_statements_writer.writeheader()
+        if args["include_item_statements"]:
+            item_statements_file_path = os.path.join(
+                args["data_path"],
+                "wikidata-derived-{}".format(args["wd_yyyymmdd"]),
+                "item-statements-chunks",
+                "kwnlp-{}-item-statements.csv".format(args["out_file_base"]),
+            )
+            os.makedirs(os.path.dirname(item_statements_file_path), exist_ok=True)
+            item_statements_fp = exit_stack.enter_context(open(item_statements_file_path, "w"))
+            fieldnames = [
+                "statement_id",
+                "mainsnak_datatype",
+                "datavalue_datatype",
+                "source_item_id",
+                "edge_property_id",
+                "target_datavalue",
+            ]
+            item_statements_writer = csv.DictWriter(item_statements_fp, fieldnames=fieldnames)
+            item_statements_writer.writeheader()
 
         property_file_path = os.path.join(
             args["data_path"],
@@ -287,27 +288,28 @@ def parse_file(args: Dict) -> None:
 
                 # write statements
                 # ---------------------------------------------------------
-                for (
-                    claim_id_str,
-                    claim_group,
-                ) in wd_entity.get_truthy_claim_groups().items():
-                    statement_rows = [
-                        {
-                            "statement_id": f"{wd_entity.entity_id}-{claim_id_str}-{i}",
-                            "mainsnak_datatype": claim.mainsnak.snak_datatype,
-                            "datavalue_datatype": claim.mainsnak.value_datatype,
-                            "source_item_id": wd_entity.entity_id[1:],
-                            "edge_property_id": claim_id_str[1:],
-                            # we must access private variable to faithfully replicate this field
-                            "target_datavalue": json.dumps(
-                                claim.mainsnak.datavalue._datavalue_dict
-                            ),
-                        }
-                        for i, claim in enumerate(claim_group)
-                        if (claim.mainsnak.snaktype == "value" and claim.rank != "deprecated")
-                    ]
-                    for row in statement_rows:
-                        item_statements_writer.writerow(row)
+                if args["include_item_statements"]:
+                    for (
+                        claim_id_str,
+                        claim_group,
+                    ) in wd_entity.get_truthy_claim_groups().items():
+                        statement_rows = [
+                            {
+                                "statement_id": f"{wd_entity.entity_id}-{claim_id_str}-{i}",
+                                "mainsnak_datatype": claim.mainsnak.snak_datatype,
+                                "datavalue_datatype": claim.mainsnak.value_datatype,
+                                "source_item_id": wd_entity.entity_id[1:],
+                                "edge_property_id": claim_id_str[1:],
+                                # we must access private variable to faithfully replicate this field
+                                "target_datavalue": json.dumps(
+                                    claim.mainsnak.datavalue._datavalue_dict
+                                ),
+                            }
+                            for i, claim in enumerate(claim_group)
+                            if (claim.mainsnak.snaktype == "value" and claim.rank != "deprecated")
+                        ]
+                        for row in statement_rows:
+                            item_statements_writer.writerow(row)
 
                 # filter articles from chosen wiki
                 # ---------------------------------------------------------
@@ -324,6 +326,7 @@ def main(
     wiki: str = argconfig.DEFAULT_KWNLP_WIKI,
     workers: int = argconfig.DEFAULT_KWNLP_WORKERS,
     max_entities: int = argconfig.DEFAULT_KWNLP_MAX_ENTITIES,
+    include_item_statements: bool = False,
 ) -> None:
 
     in_dump_paths = {
@@ -354,6 +357,7 @@ def main(
                 "wikidata_file_path": wikidata_file_path,
                 "out_file_base": out_file_base,
                 "max_entities": max_entities,
+                "include_item_statements": include_item_statements,
             }
         )
 
@@ -371,6 +375,7 @@ if __name__ == "__main__":
         "workers",
         "max_entities",
         "loglevel",
+        "include_item_statements",
     ]
     parser = argconfig.get_argparser(description, arg_names)
 
@@ -384,4 +389,5 @@ if __name__ == "__main__":
         wiki=args.wiki,
         workers=args.workers,
         max_entities=args.max_entities,
+        include_item_statements=args.include_item_statements,
     )

--- a/kwnlp_preprocessor/task_18p1_filter_wikidata_dump.py
+++ b/kwnlp_preprocessor/task_18p1_filter_wikidata_dump.py
@@ -18,9 +18,9 @@ logger = logging.getLogger(__name__)
 
 SKIP_INSTANCES_OF_NQID = frozenset(
     [
-        13442814,
+        13442814,  # scholarly article
     ]
-)  # scholarly article
+)
 
 RANK_TO_INT = {"deprecated": 2, "normal": 1, "preferred": 0}
 

--- a/kwnlp_preprocessor/task_21p1_gather_wikidata_chunks.py
+++ b/kwnlp_preprocessor/task_21p1_gather_wikidata_chunks.py
@@ -5,26 +5,31 @@ import re
 
 import pandas as pd
 
-from kwnlp_preprocessor import argconfig
-from kwnlp_preprocessor import utils
-
+from kwnlp_preprocessor import argconfig, utils
 
 logger = logging.getLogger(__name__)
 
 
-def main(wd_yyyymmdd: str, data_path: str = argconfig.DEFAULT_KWNLP_DATA_PATH) -> None:
+def main(
+    wd_yyyymmdd: str,
+    data_path: str = argconfig.DEFAULT_KWNLP_DATA_PATH,
+    include_item_statements: bool = False,
+) -> None:
 
-    for sample in [
+    files_to_include = [
         "p31-claim",
         "p279-claim",
         "qpq-claim",
         "item",
         "item-alias",
-        "item-statements",
         "property",
         "property-alias",
         "skipped-entity",
-    ]:
+    ]
+    if include_item_statements:
+        files_to_include.append("item-statements")
+
+    for sample in files_to_include:
 
         in_dump_path = os.path.join(
             data_path,
@@ -61,7 +66,7 @@ def main(wd_yyyymmdd: str, data_path: str = argconfig.DEFAULT_KWNLP_DATA_PATH) -
 if __name__ == "__main__":
 
     description = "gather wikidata chunks"
-    arg_names = ["wd_yyyymmdd", "data_path", "loglevel"]
+    arg_names = ["wd_yyyymmdd", "data_path", "loglevel", "include_item_statements"]
     parser = argconfig.get_argparser(description, arg_names)
 
     args = parser.parse_args()

--- a/kwnlp_preprocessor/task_24p1_create_kwnlp_article_pre.py
+++ b/kwnlp_preprocessor/task_24p1_create_kwnlp_article_pre.py
@@ -8,7 +8,6 @@ import pandas as pd
 
 from kwnlp_preprocessor import argconfig
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kwnlp_preprocessor/task_27p1_parse_wikitext.py
+++ b/kwnlp_preprocessor/task_27p1_parse_wikitext.py
@@ -10,16 +10,14 @@ import json
 import logging
 from multiprocessing import get_context
 import os
-import pandas as pd
 import re
 from typing import Dict, Pattern
 
 import mwtext
 import mwxml
+import pandas as pd
 
-from kwnlp_preprocessor import argconfig
-from kwnlp_preprocessor import utils
-
+from kwnlp_preprocessor import argconfig, utils
 
 logger = logging.getLogger(__name__)
 

--- a/kwnlp_preprocessor/task_30p1_post_process_link_chunks.py
+++ b/kwnlp_preprocessor/task_30p1_post_process_link_chunks.py
@@ -3,13 +3,12 @@ from collections import Counter
 import logging
 from multiprocessing import Pool
 import os
-import pandas as pd
 import re
 import typing
 
-from kwnlp_preprocessor import argconfig
-from kwnlp_preprocessor import utils
+import pandas as pd
 
+from kwnlp_preprocessor import argconfig, utils
 
 logger = logging.getLogger(__name__)
 

--- a/kwnlp_preprocessor/task_39p1_create_kwnlp_article.py
+++ b/kwnlp_preprocessor/task_39p1_create_kwnlp_article.py
@@ -7,7 +7,6 @@ import pandas as pd
 
 from kwnlp_preprocessor import argconfig
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/kwnlp_preprocessor/task_42p1_collect_section_names.py
+++ b/kwnlp_preprocessor/task_42p1_collect_section_names.py
@@ -1,12 +1,11 @@
 # Copyright 2021-present Kensho Technologies, LLC.
 import logging
 import os
-import pandas as pd
 import re
 
-from kwnlp_preprocessor import argconfig
-from kwnlp_preprocessor import utils
+import pandas as pd
 
+from kwnlp_preprocessor import argconfig, utils
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Wikidata item statements contain a ton of useful information. However, the resulting file is quite large, ~175GB, so not all users may want to compute this output.