### PR TITLE
Add version bounds for wiki libraries

### DIFF
--- a/kwnlp_preprocessor/__init__.py
+++ b/kwnlp_preprocessor/__init__.py
@@ -1,2 +1,2 @@
 # Copyright 2021-present Kensho Technologies, LLC.
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/setup.py
+++ b/setup.py
@@ -48,13 +48,13 @@ setup(
     package_data={"": []},
     install_requires=[
         "funcy",
-        "kwnlp_dump_downloader",
-        "kwnlp_sql_parser",
+        "kwnlp_dump_downloader>=0.1.0,<0.2",
+        "kwnlp_sql_parser>=0.0.2,<0.1",
         "mwtext",
         "mwxml",
         "networkx",
         "pandas",
-        "qwikidata",
+        "qwikidata>=0.4.1,<0.5",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
Since we rely on other WIki libraries that may update to fix bugs, it's important that the latest version of this library keeps track of what versions are kosher.