### PR TITLE
kwnlp-preprocessor: Catch badly formatted snak with try/except

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,3 +1,4 @@
 # Authors
 
 * Gabriel Altay (github: galtay)
+* Domenic Puzio (github: DomenicPuzio)

--- a/kwnlp_preprocessor/__init__.py
+++ b/kwnlp_preprocessor/__init__.py
@@ -1,2 +1,2 @@
 # Copyright 2021-present Kensho Technologies, LLC.
-__version__ = "0.1.3"
+__version__ = "0.1.4"

--- a/kwnlp_preprocessor/task_18p1_filter_wikidata_dump.py
+++ b/kwnlp_preprocessor/task_18p1_filter_wikidata_dump.py
@@ -243,26 +243,30 @@ def parse_file(args: Dict) -> None:
 
                 # qpq operations
                 # ---------------------------------------------------------
-                for (
-                    claim_id_str,
-                    claim_group,
-                ) in wd_entity.get_truthy_claim_groups().items():
-                    qpq_rows = [
-                        {
-                            "source_id": source_id,
-                            "property_id": claim_id_str[1:],
-                            "target_id": claim.mainsnak.datavalue.value["numeric-id"],
-                            "rnk": RANK_TO_INT[claim.rank],
-                        }
-                        for claim in claim_group
-                        if (
-                            claim.mainsnak.snaktype == "value"
-                            and claim.rank != "deprecated"
-                            and claim.mainsnak.snak_datatype == "wikibase-item"
-                        )
-                    ]
-                    for row in qpq_rows:
-                        qpq_writer.writerow(row)
+                try:
+                    for (
+                        claim_id_str,
+                        claim_group,
+                    ) in wd_entity.get_truthy_claim_groups().items():
+                        qpq_rows = [
+                            {
+                                "source_id": source_id,
+                                "property_id": claim_id_str[1:],
+                                "target_id": claim.mainsnak.datavalue.value["numeric-id"],
+                                "rnk": RANK_TO_INT[claim.rank],
+                            }
+                            for claim in claim_group
+                            if (
+                                    claim.mainsnak.snaktype == "value"
+                                    and claim.rank != "deprecated"
+                                    and claim.mainsnak.snak_datatype == "wikibase-item"
+                            )
+                        ]
+                        for row in qpq_rows:
+                            qpq_writer.writerow(row)
+                except ValueError as e:
+                    logger.info("ValueError for entity %s", wd_entity)
+                    logger.exception(e)
 
                 # write label and description
                 # ---------------------------------------------------------


### PR DESCRIPTION
# Summary
In this `20230123` Wikidata dump, there is a single Entity with a single Claim that is missing the correct keys for one of its Snaks. This causes the whole ingestion process to fail at `task_18p1_filter_wikidata_dump`. This PR wraps the verification of Claims in a try/except to log the ValueError and keep going.

# Testing
These changes were tested to ensure that the task could run completely and the correct error was logged.